### PR TITLE
Redesign workout results page in Windows 2000 style

### DIFF
--- a/src/components/ButtonPlusIcon/ButtonPlusIcon.tsx
+++ b/src/components/ButtonPlusIcon/ButtonPlusIcon.tsx
@@ -7,12 +7,6 @@ interface ButtonPlusIconProps {
     variant?: "floating" | "inline"
 }
 
-const sizeClasses = {
-    small: 'h-10 w-10',
-    medium: 'h-12 w-12',
-    large: 'h-14 w-14',
-}
-
 const ButtonPlusIcon = ({
     onClick,
     icon,
@@ -25,15 +19,16 @@ const ButtonPlusIcon = ({
                 <button
                     type="button"
                     onClick={onClick}
-                    className={`${sizeClasses[size]} flex items-center justify-center rounded-full bg-primary-dark text-[#121212] shadow-md hover:bg-[#64b5f6] active:shadow-lg transition-all cursor-pointer`}
+                    className="win2k-btn flex items-center gap-1 px-4"
                     aria-label="add"
                 >
                     {icon || (
-                        <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                             <line x1="12" y1="5" x2="12" y2="19" />
                             <line x1="5" y1="12" x2="19" y2="12" />
                         </svg>
                     )}
+                    <span className="text-[11px]">Add Set</span>
                 </button>
             </div>
         )
@@ -43,15 +38,16 @@ const ButtonPlusIcon = ({
         <button
             type="button"
             onClick={onClick}
-            className={`${sizeClasses[size]} fixed bottom-8 right-8 z-40 flex items-center justify-center rounded-full bg-primary-dark text-[#121212] shadow-lg hover:bg-[#64b5f6] active:shadow-xl transition-all cursor-pointer`}
+            className="win2k-btn fixed bottom-8 right-8 z-40 flex items-center gap-1 px-4"
             aria-label="add"
         >
             {icon || (
-                <svg xmlns="http://www.w3.org/2000/svg" width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
+                <svg xmlns="http://www.w3.org/2000/svg" width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round">
                     <line x1="12" y1="5" x2="12" y2="19" />
                     <line x1="5" y1="12" x2="19" y2="12" />
                 </svg>
             )}
+            <span className="text-[11px]">Add</span>
         </button>
     )
 }

--- a/src/components/NavbarOnlyTitle/NavbarOnlyTitle.tsx
+++ b/src/components/NavbarOnlyTitle/NavbarOnlyTitle.tsx
@@ -5,11 +5,19 @@ const NavbarOnlyTitle = ({ title, children }: { title: string, children?: ReactN
     const { t } = useTranslation()
 
     return (
-        <div className="w-full flex items-center">
-            <h1 className="flex-1 text-lg font-semibold text-zinc-200">{t(title)}</h1>
+        <div className="win2k-titlebar w-full select-none">
+            {/* Win2k window icon */}
+            <span className="text-xs leading-none">🏋️</span>
+            <h1 className="flex-1 text-[11px] font-bold text-white truncate">{t(title)}</h1>
             {children && (
                 <div className="flex items-center gap-1">{children}</div>
             )}
+            {/* Win2k window control buttons */}
+            <div className="flex items-center gap-px ml-1">
+                <button className="win2k-btn !px-1 !py-0 !min-h-0 h-[14px] w-[16px] text-[9px] font-bold leading-none flex items-center justify-center" aria-label="minimize">_</button>
+                <button className="win2k-btn !px-1 !py-0 !min-h-0 h-[14px] w-[16px] text-[9px] font-bold leading-none flex items-center justify-center" aria-label="maximize">□</button>
+                <button className="win2k-btn !px-1 !py-0 !min-h-0 h-[14px] w-[16px] text-[10px] font-bold leading-none flex items-center justify-center text-black" aria-label="close">✕</button>
+            </div>
         </div>
     )
 }

--- a/src/containers/Workout/BoxExercise/BoxExercise.tsx
+++ b/src/containers/Workout/BoxExercise/BoxExercise.tsx
@@ -95,58 +95,62 @@ const BaseBoxExercise = ({
     }, [exercise])
 
     return (
-        <div className="flex w-full flex-col gap-2 text-center text-sm">
-            <div className="flex flex-1 flex-row items-center justify-center rounded bg-primary-dark p-2 text-[#121212]">
-                <div>
-                    {isOwner && (
-                        <DialogConfirm onConfirmed={deleteExerciseWithIndex}>
-                            <button className="rounded-full p-2 hover:bg-gray-100 dark:hover:bg-gray-800">
-                                <Trash2 size={20} />
-                            </button>
-                        </DialogConfirm>
-                    )}
-                </div>
-                <div className="flex-1">
+        <div className="flex w-full flex-col gap-1 text-center text-xs win2k-window">
+            {/* Win2k panel header / title bar */}
+            <div className="win2k-titlebar px-2 py-1 flex items-center gap-2">
+                {isOwner && (
+                    <DialogConfirm onConfirmed={deleteExerciseWithIndex}>
+                        <button className="win2k-btn !px-1 !py-0 !min-h-0 h-[16px] text-[10px] flex items-center justify-center text-black" aria-label="delete exercise">
+                            <Trash2 size={10} />
+                        </button>
+                    </DialogConfirm>
+                )}
+                <div className="flex-1 text-left font-bold text-white text-[11px]">
                     {exercise.name} ({exerciseFromWorkoutPlan?.series ?? 1}x
                     {exerciseFromWorkoutPlan?.reps ?? 1})
                 </div>
-                <div>{exerciseFromWorkoutPlan?.rir ?? 0} RIR</div>
+                <div className="text-white text-[10px]">{exerciseFromWorkoutPlan?.rir ?? 0} RIR</div>
             </div>
-            <div>{exerciseFromWorkoutPlan?.note}</div>
-            {!!previousExercise?.results?.length && (
-                <div className="flex flex-col gap-1 opacity-50">
-                    {previousExercise.results.map((result, index) => (
-                        <div key={index} className="flex flex-row border border-dashed p-2 rounded items-center justify-center">
-                            <div className="flex-1">{result.weight}kg</div>
-                            <div className="flex-1">#{index + 1}</div>
-                            <div className="flex-1">{result.reps}r.</div>
-                            <div className="flex-1">{result.rir ?? 0} RIR</div>
-                        </div>
-                    ))}
-                </div>
-            )}
-            {values.map(
-                (value: WorkoutResultExerciseResultSchema, index: number) => (
-                    <BoxResult
-                        key={index + ' ' + value.open}
-                        value={value}
-                        index={index}
-                        deleteResult={() => deleteResult(index)}
-                        changeResult={(object) => changeResult(object, index)}
-                        isOwner={isOwner}
-                        isLast={index + 1 === values.length}
-                        openNewResult={openNewResult}
-                        previousSetAt={index > 0 ? values[index - 1]?.setAt : undefined}
+
+            <div className="px-2 pb-1">
+                {exerciseFromWorkoutPlan?.note && (
+                    <div className="text-[10px] text-[#444444] text-left py-1">{exerciseFromWorkoutPlan.note}</div>
+                )}
+                {!!previousExercise?.results?.length && (
+                    <div className="flex flex-col gap-1 opacity-50 mb-1">
+                        {previousExercise.results.map((result, index) => (
+                            <div key={index} className="flex flex-row p-1 items-center justify-center border border-dashed border-[#808080] bg-[#e8e4d8]">
+                                <div className="flex-1 text-[10px]">{result.weight}kg</div>
+                                <div className="flex-1 text-[10px]">#{index + 1}</div>
+                                <div className="flex-1 text-[10px]">{result.reps}r.</div>
+                                <div className="flex-1 text-[10px]">{result.rir ?? 0} RIR</div>
+                            </div>
+                        ))}
+                    </div>
+                )}
+                {values.map(
+                    (value: WorkoutResultExerciseResultSchema, index: number) => (
+                        <BoxResult
+                            key={index + ' ' + value.open}
+                            value={value}
+                            index={index}
+                            deleteResult={() => deleteResult(index)}
+                            changeResult={(object) => changeResult(object, index)}
+                            isOwner={isOwner}
+                            isLast={index + 1 === values.length}
+                            openNewResult={openNewResult}
+                            previousSetAt={index > 0 ? values[index - 1]?.setAt : undefined}
+                        />
+                    )
+                )}
+                {isOwner && !values.length && (
+                    <ButtonPlusIcon
+                        size="small"
+                        variant="inline"
+                        onClick={() => openNewResult(null)}
                     />
-                )
-            )}
-            {isOwner && !values.length && (
-                <ButtonPlusIcon
-                    size="small"
-                    variant="inline"
-                    onClick={() => openNewResult(null)}
-                />
-            )}
+                )}
+            </div>
         </div>
     )
 }

--- a/src/containers/Workout/BoxResult/BoxResult.tsx
+++ b/src/containers/Workout/BoxResult/BoxResult.tsx
@@ -159,14 +159,14 @@ const BoxResult = ({
             {open && isOwner ? (
                 <>
                     <div
-                        className="flex flex-row border p-2 rounded items-center justify-center"
+                        className="flex flex-row win2k-sunken p-1 items-center justify-center cursor-pointer"
                         onClick={() => {
                             setOpen(false)
                             changeResult(buildResult({ open: false }))
                         }}
                     >
-                        <div className="flex-1">Click to save</div>
-                        <div className="flex-1 flex flex-col items-center text-xs opacity-60">
+                        <div className="flex-1 text-[11px] font-bold text-black">Click to save</div>
+                        <div className="flex-1 flex flex-col items-center text-[10px] text-[#444444]">
                             {mmss ? (
                                 <>
                                     <span>{mmss}</span>
@@ -176,22 +176,22 @@ const BoxResult = ({
                                 <span>{`#${index + 1}`}</span>
                             )}
                         </div>
-                        <div className="flex-1">
-                            <button className="rounded-full p-2 hover:bg-gray-100 dark:hover:bg-gray-800" aria-label="arrow">
-                                <ArrowRight size={20} />
+                        <div className="flex-1 flex justify-center">
+                            <button className="win2k-btn flex items-center gap-1" aria-label="arrow">
+                                <ArrowRight size={11} />
                             </button>
                         </div>
-                        <div className="flex-1">
-                            <button className="rounded-full p-2 hover:bg-gray-100 dark:hover:bg-gray-800" aria-label="save">
-                                <Circle size={20} />
+                        <div className="flex-1 flex justify-center">
+                            <button className="win2k-btn flex items-center gap-1" aria-label="save">
+                                <Circle size={11} />
                             </button>
                         </div>
                     </div>
-                    <div className="mt-2">
-                        <label className="mb-1 block text-sm text-gray-500">Weight</label>
-                        <div className="flex items-center rounded border border-gray-300 focus-within:border-primary-dark dark:border-gray-600">
+                    <div className="mt-1">
+                        <label className="mb-px block text-[10px] text-[#444444] text-left">Weight</label>
+                        <div className="flex items-center win2k-sunken">
                             <input
-                                className="flex-1 bg-transparent px-3 py-2 outline-none"
+                                className="flex-1 bg-white px-2 py-1 text-[11px] text-black outline-none"
                                 list="weight-options"
                                 value={weight}
                                 onChange={(e) => {
@@ -209,10 +209,10 @@ const BoxResult = ({
                             ))}
                         </datalist>
                     </div>
-                    <div className="mt-2">
-                        <label className="mb-1 block text-sm text-gray-500">Reps</label>
+                    <div className="mt-1">
+                        <label className="mb-px block text-[10px] text-[#444444] text-left">Reps</label>
                         <select
-                            className="w-full rounded border border-gray-300 bg-transparent px-3 py-2 outline-none focus:border-primary-dark dark:border-gray-600"
+                            className="w-full win2k-sunken bg-white px-2 py-1 text-[11px] text-black outline-none"
                             value={reps}
                             onChange={(e) => {
                                 setReps(e.target.value)
@@ -227,10 +227,10 @@ const BoxResult = ({
                             ))}
                         </select>
                     </div>
-                    <div className="mt-2">
-                        <label className="mb-1 block text-sm text-gray-500">RIR</label>
+                    <div className="mt-1">
+                        <label className="mb-px block text-[10px] text-[#444444] text-left">RIR</label>
                         <select
-                            className="w-full rounded border border-gray-300 bg-transparent px-3 py-2 outline-none focus:border-primary-dark dark:border-gray-600"
+                            className="w-full win2k-sunken bg-white px-2 py-1 text-[11px] text-black outline-none"
                             value={rir}
                             onChange={(e) => {
                                 setRir(e.target.value)
@@ -246,10 +246,10 @@ const BoxResult = ({
                         </select>
                     </div>
                     {setAt && (
-                        <div className="mt-2">
-                            <label className="mb-1 block text-sm text-gray-500">Finished at (mm:ss)</label>
+                        <div className="mt-1">
+                            <label className="mb-px block text-[10px] text-[#444444] text-left">Finished at (mm:ss)</label>
                             <input
-                                className="w-full rounded border border-gray-300 bg-transparent px-3 py-2 outline-none focus:border-primary-dark dark:border-gray-600"
+                                className="w-full win2k-sunken bg-white px-2 py-1 text-[11px] text-black outline-none"
                                 placeholder="MM:SS"
                                 value={localTimeDisplay}
                                 onChange={(e) => setLocalTimeDisplay(e.target.value)}
@@ -266,24 +266,24 @@ const BoxResult = ({
                     )}
                 </>
             ) : (
-                <div onClick={() => setOpen(true)} className="flex flex-row border p-2 rounded items-center justify-center">
+                <div onClick={() => setOpen(true)} className="flex flex-row win2k-raised p-1 items-center justify-center cursor-pointer hover:bg-[#c8c4b8]">
                     <div className="flex-1">
                         {isOwner && (
                             <DialogConfirm onConfirmed={deleteResult}>
-                                <button className="rounded-full p-2 hover:bg-gray-100 dark:hover:bg-gray-800" aria-label="delete">
-                                    <Trash2 size={20} />
+                                <button className="win2k-btn !px-1 !py-0 !min-h-0 h-[18px] w-[20px] text-[10px] flex items-center justify-center" aria-label="delete">
+                                    <Trash2 size={11} />
                                 </button>
                             </DialogConfirm>
                         )}
                     </div>
-                    <div className="flex-1">{weight}kg</div>
-                    <div className="flex-1 flex flex-col items-center text-xs">
-                        <span className="font-semibold">#{index + 1}</span>
-                        {mmss && <span className="opacity-60">{mmss}</span>}
-                        {diff && <span className="opacity-60">rest {diff}</span>}
+                    <div className="flex-1 text-[11px] text-black font-semibold">{weight}kg</div>
+                    <div className="flex-1 flex flex-col items-center text-[10px]">
+                        <span className="font-bold text-black">#{index + 1}</span>
+                        {mmss && <span className="text-[#444444]">{mmss}</span>}
+                        {diff && <span className="text-[#444444]">rest {diff}</span>}
                     </div>
-                    <div className="flex-1">{reps}r.</div>
-                    <div className="flex-1">{rir} RIR</div>
+                    <div className="flex-1 text-[11px] text-black">{reps}r.</div>
+                    <div className="flex-1 text-[11px] text-black">{rir} RIR</div>
                 </div>
             )}
             {isOwner && isLast && (

--- a/src/containers/Workout/BoxWorkout/BoxWorkout.tsx
+++ b/src/containers/Workout/BoxWorkout/BoxWorkout.tsx
@@ -20,22 +20,23 @@ const BoxWorkout = ({
     return (
         <Link
             href={route}
-            className="glass-interactive flex w-full p-4 cursor-pointer"
+            className="glass-interactive flex w-full p-2 cursor-pointer items-center gap-2"
         >
-            <div className="flex flex-1 flex-col gap-1 min-w-0">
-                <h2 className="text-sm font-bold text-zinc-200 truncate">{title}</h2>
-                {description && (
-                    <p className="text-xs text-[#7a7a7a] line-clamp-2">{description}</p>
-                )}
-                {whenAdded && (
-                    <div className="text-[11px] text-[#7a7a7a] mt-auto pt-2">
-                        {moment(whenAdded).format('DD.MM.YYYY')}
-                    </div>
-                )}
-            </div>
-            <div className="flex w-10 items-center justify-center shrink-0 text-[#7a7a7a]">
+            {/* Win2k icon container */}
+            <div className="flex w-8 h-8 items-center justify-center shrink-0 text-[#0a246a]">
                 {icon}
             </div>
+            <div className="flex flex-1 flex-col gap-0 min-w-0">
+                <h2 className="text-xs font-bold text-black truncate">{title}</h2>
+                {description && (
+                    <p className="text-[10px] text-[#444444] line-clamp-1">{description}</p>
+                )}
+            </div>
+            {whenAdded && (
+                <div className="text-[10px] text-[#444444] shrink-0 pr-1">
+                    {moment(whenAdded).format('DD.MM.YYYY')}
+                </div>
+            )}
         </Link>
     )
 }

--- a/src/containers/Workout/NavbarWorkout/NavbarWorkout.tsx
+++ b/src/containers/Workout/NavbarWorkout/NavbarWorkout.tsx
@@ -24,36 +24,51 @@ const NavbarWorkout = ({
     const { data: sessionData } = useSession()
 
     return (
-        <div className="flex w-full">
-            <button className="rounded-full p-2 hover:bg-gray-100 dark:hover:bg-gray-800 m-auto" aria-label="route" onClick={onArrowBack}>
-                <ArrowLeft />
-            </button>
-            <div className="flex-1" />
-            {sessionData?.user?.username == router.query.login
-                ? <>
-                    <DialogConfirm onConfirmed={onDelete} isDisabled={isDisabled}>
-                        <button disabled={isDisabled} className="rounded-full p-2 hover:bg-gray-100 dark:hover:bg-gray-800 m-auto disabled:opacity-50" aria-label="delete">
-                            <Trash2 />
+        <div className="win2k-titlebar w-full select-none">
+            {/* Win2k icon */}
+            <span className="text-xs leading-none">🏋️</span>
+            <div className="flex-1 text-[11px] font-bold text-white truncate">Workout Result</div>
+            {/* Toolbar buttons */}
+            <div className="flex items-center gap-1">
+                <button
+                    className="win2k-btn flex items-center gap-1"
+                    aria-label="Back"
+                    onClick={onArrowBack}
+                >
+                    <ArrowLeft size={11} /> Back
+                </button>
+                {sessionData?.user?.username == router.query.login && (
+                    <>
+                        <DialogConfirm onConfirmed={onDelete} isDisabled={isDisabled}>
+                            <button
+                                disabled={isDisabled}
+                                className="win2k-btn flex items-center gap-1"
+                                aria-label="delete"
+                            >
+                                <Trash2 size={11} /> Delete
+                            </button>
+                        </DialogConfirm>
+                        <button
+                            disabled={isDisabled || isLoading}
+                            onClick={onSave}
+                            className="win2k-btn flex items-center gap-1"
+                        >
+                            {isLoading ? (
+                                <span className="inline-block h-3 w-3 animate-spin rounded-full border-2 border-black border-t-transparent" />
+                            ) : (
+                                <Save size={11} />
+                            )}
+                            {t('Save')}
                         </button>
-                    </DialogConfirm>
-                    <button
-                        disabled={isDisabled || isLoading}
-                        onClick={onSave}
-                        className="rounded bg-primary-dark px-4 py-2 text-[#121212] hover:bg-[#64b5f6] disabled:opacity-50 flex items-center gap-2"
-                    >
-                        {isLoading ? (
-                            <span className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-white border-t-transparent" />
-                        ) : (
-                            <Save size={18} />
-                        )}
-                        {t('Save')}
-                    </button>
-                </>
-                : <>
-                    <div />
-                    <div />
-                </>
-            }
+                    </>
+                )}
+            </div>
+            {/* Win2k window control buttons */}
+            <div className="flex items-center gap-px ml-1">
+                <button className="win2k-btn !px-1 !py-0 !min-h-0 h-[14px] w-[16px] text-[9px] font-bold leading-none flex items-center justify-center" aria-label="minimize">_</button>
+                <button className="win2k-btn !px-1 !py-0 !min-h-0 h-[14px] w-[16px] text-[9px] font-bold leading-none flex items-center justify-center" aria-label="maximize">□</button>
+                <button className="win2k-btn !px-1 !py-0 !min-h-0 h-[14px] w-[16px] text-[10px] font-bold leading-none flex items-center justify-center text-black" aria-label="close">✕</button>
+            </div>
         </div>
     );
 }

--- a/src/pages/[login]/workout/results/[id].tsx
+++ b/src/pages/[login]/workout/results/[id].tsx
@@ -166,7 +166,7 @@ const WorkoutResultPage = () => {
         deleteWorkoutResult.isPending
 
     return (
-        <form className="flex flex-1 flex-col gap-3">
+        <form className="flex flex-1 flex-col gap-2">
             <NavbarWorkout
                 isDisabled={isLoading}
                 isLoading={isLoading}
@@ -175,94 +175,100 @@ const WorkoutResultPage = () => {
                 onArrowBack={() => router.push(`/${username}/workout/results`)}
             />
 
-            <div>
-                <label className="mb-1 block text-sm text-gray-500">{t('Title')}</label>
-                <textarea
-                    className="w-full rounded border border-gray-300 bg-transparent px-3 py-2 outline-none focus:border-primary-dark dark:border-gray-600"
-                    {...register('name')}
-                />
-                {errors.name && <p className="mt-1 text-xs text-red-500">{errors.name.message}</p>}
-            </div>
-
-            <DatePicker
-                defaultDate={data?.whenAdded || moment().toDate()}
-                onChange={(newWhenAdded) => setValue('whenAdded', newWhenAdded)}
-                register={register('whenAdded')}
-                focused
-                maxDateTime={moment().add(2, 'hour').toDate()}
-            />
-
-            <DatePicker
-                label={t('Finished at')}
-                defaultDate={
-                    data?.finishedAt
-                        ? moment(data.finishedAt as unknown as Date).toDate()
-                        : moment().toDate()
-                }
-                onChange={(newFinishedAt) =>
-                    setValue('finishedAt', newFinishedAt)
-                }
-                register={register('finishedAt')}
-                focused
-                maxDateTime={moment().add(2, 'hour').toDate()}
-            />
-
-            <div>
-                <label className="mb-1 block text-sm text-gray-500">{t('Burnt')}</label>
-                <div className="flex items-center rounded border border-gray-300 focus-within:border-primary-dark dark:border-gray-600">
-                    <input
-                        className="flex-1 bg-transparent px-3 py-2 outline-none"
-                        type="number"
-                        {...register('burnedCalories')}
-                    />
-                    <span className="px-3 text-sm text-gray-500">kcal</span>
-                </div>
-                {errors.burnedCalories && <p className="mt-1 text-xs text-red-500">{errors.burnedCalories.message}</p>}
-            </div>
-
-            <div>
-                <label className="mb-1 block text-sm text-gray-500">{t('Notes')}</label>
-                <textarea
-                    className="w-full rounded border border-gray-300 bg-transparent px-3 py-2 outline-none focus:border-primary-dark dark:border-gray-600"
-                    {...register('note')}
-                />
-                {errors.note && <p className="mt-1 text-xs text-red-500">{errors.note.message}</p>}
-            </div>
-
-            {data?.workoutPlan?.description && (
+            {/* Win2k window body */}
+            <div className="win2k-window p-3 flex flex-col gap-2">
                 <div>
-                    <label className="mb-1 block text-sm text-gray-500">{t('Description of workout plan')}</label>
+                    <label className="mb-px block text-[10px] text-[#444444]">{t('Title')}</label>
                     <textarea
-                        className="w-full rounded border border-gray-300 bg-transparent px-3 py-2 outline-none dark:border-gray-600"
-                        disabled
-                        defaultValue={data.workoutPlan.description}
+                        className="w-full win2k-sunken bg-white px-2 py-1 text-[11px] text-black outline-none resize-none"
+                        rows={2}
+                        {...register('name')}
                     />
+                    {errors.name && <p className="mt-1 text-[10px] text-red-600">{errors.name.message}</p>}
                 </div>
-            )}
 
-            {sessionData?.user?.username == username && (
-                <label className="flex items-center gap-2 text-sm">
-                    <div
-                        role="switch"
-                        aria-checked={searchAllPlans}
-                        onClick={() => {
-                            const newValue = !searchAllPlans
-                            setSearchAllPlans(newValue)
-                            updateUser.mutate(
-                                { searchAllPlans: newValue },
-                                {
-                                    onError: () =>
-                                        setSearchAllPlans(!newValue),
-                                }
-                            )
-                        }}
-                        className={`relative h-6 w-11 cursor-pointer rounded-full transition-colors ${searchAllPlans ? 'bg-primary-dark' : 'bg-gray-300 dark:bg-gray-600'}`}
-                    >
-                        <span className={`absolute top-0.5 left-0.5 h-5 w-5 rounded-full bg-white shadow transition-transform ${searchAllPlans ? 'translate-x-5' : ''}`} />
+                <DatePicker
+                    defaultDate={data?.whenAdded || moment().toDate()}
+                    onChange={(newWhenAdded) => setValue('whenAdded', newWhenAdded)}
+                    register={register('whenAdded')}
+                    focused
+                    maxDateTime={moment().add(2, 'hour').toDate()}
+                />
+
+                <DatePicker
+                    label={t('Finished at')}
+                    defaultDate={
+                        data?.finishedAt
+                            ? moment(data.finishedAt as unknown as Date).toDate()
+                            : moment().toDate()
+                    }
+                    onChange={(newFinishedAt) =>
+                        setValue('finishedAt', newFinishedAt)
+                    }
+                    register={register('finishedAt')}
+                    focused
+                    maxDateTime={moment().add(2, 'hour').toDate()}
+                />
+
+                <div>
+                    <label className="mb-px block text-[10px] text-[#444444]">{t('Burnt')}</label>
+                    <div className="flex items-center win2k-sunken">
+                        <input
+                            className="flex-1 bg-white px-2 py-1 text-[11px] text-black outline-none"
+                            type="number"
+                            {...register('burnedCalories')}
+                        />
+                        <span className="px-2 text-[10px] text-[#444444]">kcal</span>
                     </div>
-                    {t('SEARCH_ALL_PLANS')}
-                </label>
-            )}
+                    {errors.burnedCalories && <p className="mt-1 text-[10px] text-red-600">{errors.burnedCalories.message}</p>}
+                </div>
+
+                <div>
+                    <label className="mb-px block text-[10px] text-[#444444]">{t('Notes')}</label>
+                    <textarea
+                        className="w-full win2k-sunken bg-white px-2 py-1 text-[11px] text-black outline-none resize-none"
+                        rows={2}
+                        {...register('note')}
+                    />
+                    {errors.note && <p className="mt-1 text-[10px] text-red-600">{errors.note.message}</p>}
+                </div>
+
+                {data?.workoutPlan?.description && (
+                    <div>
+                        <label className="mb-px block text-[10px] text-[#444444]">{t('Description of workout plan')}</label>
+                        <textarea
+                            className="w-full win2k-sunken bg-[#e8e4d8] px-2 py-1 text-[11px] text-[#444444] outline-none resize-none"
+                            rows={2}
+                            disabled
+                            defaultValue={data.workoutPlan.description}
+                        />
+                    </div>
+                )}
+
+                {sessionData?.user?.username == username && (
+                    <label className="flex items-center gap-2 text-[11px] text-black cursor-pointer">
+                        <div
+                            role="switch"
+                            aria-checked={searchAllPlans}
+                            onClick={() => {
+                                const newValue = !searchAllPlans
+                                setSearchAllPlans(newValue)
+                                updateUser.mutate(
+                                    { searchAllPlans: newValue },
+                                    {
+                                        onError: () =>
+                                            setSearchAllPlans(!newValue),
+                                    }
+                                )
+                            }}
+                            className={`relative h-5 w-10 cursor-pointer transition-colors win2k-sunken ${searchAllPlans ? 'bg-[#0a246a]' : 'bg-[#d4d0c8]'}`}
+                        >
+                            <span className={`absolute top-0.5 left-0.5 h-4 w-4 bg-[#d4d0c8] shadow win2k-raised transition-transform ${searchAllPlans ? 'translate-x-5' : ''}`} />
+                        </div>
+                        {t('SEARCH_ALL_PLANS')}
+                    </label>
+                )}
+            </div>
 
             {fields.map((exercise, index: number) => (
                 <div
@@ -320,24 +326,33 @@ const WorkoutResultPage = () => {
             {showFinishTimeModal && (
                 <div className="fixed inset-0 z-50 flex items-center justify-center">
                     <div className="fixed inset-0 bg-black/50" onClick={handleCloseFinishTimeModal} />
-                    <div className="relative z-50 w-full max-w-lg rounded-lg bg-white p-0 shadow-xl dark:bg-gray-900">
-                        <div className="px-6 pt-6 text-lg font-semibold">{t('Update workout finish time?')}</div>
-                        <div className="px-6 py-4">
-                            <p className="text-sm text-gray-500">
+                    {/* Win2k dialog window */}
+                    <div className="relative z-50 w-full max-w-sm win2k-window">
+                        {/* Title bar */}
+                        <div className="win2k-titlebar px-2 py-1">
+                            <span className="text-[11px]">⚠️</span>
+                            <span className="flex-1 text-[11px] font-bold text-white">{t('Update workout finish time?')}</span>
+                            <button
+                                className="win2k-btn !px-1 !py-0 !min-h-0 h-[14px] w-[16px] text-[10px] font-bold leading-none flex items-center justify-center text-black"
+                                onClick={handleCloseFinishTimeModal}
+                                aria-label="close"
+                            >✕</button>
+                        </div>
+                        {/* Content */}
+                        <div className="px-4 py-3 bg-[#d4d0c8]">
+                            <p className="text-[11px] text-black">
                                 {moment().format('YYYY-MM-DD HH:mm (Z)')}
                             </p>
                         </div>
-                        <div className="flex justify-end gap-2 px-6 pb-6">
-                            <button className="px-4 py-2 text-primary-dark hover:bg-[rgba(255,255,255,0.04)]" onClick={handleCloseFinishTimeModal}>
+                        {/* Footer buttons */}
+                        <div className="flex justify-end gap-2 px-4 pb-3 bg-[#d4d0c8]">
+                            <button className="win2k-btn" onClick={handleCloseFinishTimeModal}>
                                 {t('Close')}
                             </button>
-                            <button className="px-4 py-2 text-primary-dark hover:bg-[rgba(255,255,255,0.04)]" onClick={handleSkipFinishTime}>
+                            <button className="win2k-btn" onClick={handleSkipFinishTime}>
                                 {t('Skip')}
                             </button>
-                            <button
-                                className="rounded bg-primary-dark px-4 py-2 text-[#121212] hover:bg-[#64b5f6] disabled:opacity-50"
-                                onClick={handleAcceptFinishTime}
-                            >
+                            <button className="win2k-btn font-bold" onClick={handleAcceptFinishTime}>
                                 {t('Accept')}
                             </button>
                         </div>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -15,6 +15,91 @@
     --color-macro-carbs: #60a5fa;
     --color-macro-fat: #fb923c;
     --color-macro-kcal: #34d399;
+
+    /* Windows 2000 theme tokens */
+    --color-win2k-bg: #d4d0c8;
+    --color-win2k-surface: #d4d0c8;
+    --color-win2k-titlebar: #0a246a;
+    --color-win2k-titlebar-end: #a6caf0;
+    --color-win2k-text: #000000;
+    --color-win2k-text-muted: #444444;
+    --color-win2k-border-light: #ffffff;
+    --color-win2k-border-dark: #808080;
+    --color-win2k-border-darker: #404040;
+    --color-win2k-button: #d4d0c8;
+    --color-win2k-button-active: #a0a090;
+    --color-win2k-link: #0000ee;
+}
+
+/* Windows 2000 raised border (classic 3D look) */
+@utility win2k-raised {
+    border-top: 2px solid #ffffff;
+    border-left: 2px solid #ffffff;
+    border-right: 2px solid #404040;
+    border-bottom: 2px solid #404040;
+    outline: 1px solid #808080;
+    background: #d4d0c8;
+}
+
+/* Windows 2000 sunken border (inset 3D look) */
+@utility win2k-sunken {
+    border-top: 2px solid #808080;
+    border-left: 2px solid #808080;
+    border-right: 2px solid #ffffff;
+    border-bottom: 2px solid #ffffff;
+    outline: 1px solid #404040;
+    background: #ffffff;
+}
+
+/* Windows 2000 button */
+@utility win2k-btn {
+    background: #d4d0c8;
+    border-top: 2px solid #ffffff;
+    border-left: 2px solid #ffffff;
+    border-right: 2px solid #404040;
+    border-bottom: 2px solid #404040;
+    outline: 1px solid #808080;
+    color: #000000;
+    font-family: 'Tahoma', 'MS Sans Serif', sans-serif;
+    font-size: 11px;
+    padding: 2px 10px;
+    cursor: pointer;
+    min-height: 23px;
+    &:active {
+        border-top: 2px solid #404040;
+        border-left: 2px solid #404040;
+        border-right: 2px solid #ffffff;
+        border-bottom: 2px solid #ffffff;
+    }
+    &:disabled {
+        color: #808080;
+        cursor: default;
+    }
+}
+
+/* Windows 2000 window panel */
+@utility win2k-window {
+    background: #d4d0c8;
+    border-top: 2px solid #ffffff;
+    border-left: 2px solid #ffffff;
+    border-right: 2px solid #404040;
+    border-bottom: 2px solid #404040;
+    outline: 1px solid #808080;
+}
+
+/* Windows 2000 title bar gradient */
+@utility win2k-titlebar {
+    background: linear-gradient(to right, #0a246a, #a6caf0);
+    color: #ffffff;
+    font-family: 'Tahoma', 'MS Sans Serif', sans-serif;
+    font-size: 11px;
+    font-weight: bold;
+    padding: 2px 4px;
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    min-height: 20px;
+    user-select: none;
 }
 
 @utility glass {
@@ -25,13 +110,27 @@
 }
 
 @utility glass-interactive {
-    background: rgba(255, 255, 255, 0.02);
-    border: 1px solid rgba(255, 255, 255, 0.06);
-    border-radius: 1rem;
-    transition: all 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+    /* Win2k override */
+    background: #d4d0c8;
+    border-top: 2px solid #ffffff;
+    border-left: 2px solid #ffffff;
+    border-right: 2px solid #404040;
+    border-bottom: 2px solid #404040;
+    outline: 1px solid #808080;
+    border-radius: 0;
+    transition: none;
+    color: #000000;
+    font-family: 'Tahoma', 'MS Sans Serif', sans-serif;
+    font-size: 11px;
     &:hover {
-        background: rgba(255, 255, 255, 0.04);
-        border-color: rgba(255, 255, 255, 0.12);
+        background: #c8c4b8;
+        border-color: unset;
+    }
+    &:active {
+        border-top: 2px solid #404040;
+        border-left: 2px solid #404040;
+        border-right: 2px solid #ffffff;
+        border-bottom: 2px solid #ffffff;
     }
 }
 
@@ -106,7 +205,7 @@
     --BothNavHeightAndPadding: calc(
         var(--BothNavHeightAndPaddingDefault) + 24px
     ); /* 24px => padding in globla grid */
-    --theme-background: #121212;
+    --theme-background: #d4d0c8;
 }
 
 html {
@@ -123,8 +222,9 @@ html {
 body {
     word-break: break-word;
     margin: 0;
-    font-family: 'Quicksand', sans-serif;
-    color: #7a7a7a;
+    font-family: 'Tahoma', 'MS Sans Serif', 'Arial', sans-serif;
+    font-size: 11px;
+    color: #000000;
     background: var(--theme-background);
     background-color: var(--theme-background);
 }


### PR DESCRIPTION
## Windows 2000 Style Redesign

Redesigns the `/[login]/workout/results` page and related components to match the classic Microsoft Windows 2000 aesthetic.

### Changes

- **`global.css`** — Added Win2k design tokens (`#d4d0c8` silver background, `#0a246a` navy title bar gradient) and CSS utilities: `win2k-raised`, `win2k-sunken`, `win2k-btn`, `win2k-window`, `win2k-titlebar`. Also overrides `glass-interactive` to use the 3D beveled Win2k border look. Updated body font to `Tahoma`/`MS Sans Serif`.
- **`NavbarOnlyTitle`** — Renders as a Win2k title bar with gradient navy background, window icon, and classic minimize/maximize/close chrome buttons.
- **`NavbarWorkout`** — Same Win2k title bar treatment with inline toolbar `Back`, `Delete`, and `Save` buttons using `win2k-btn` style.
- **`BoxWorkout`** — List items now display with the 3D raised Win2k panel border.
- **`BoxExercise`** — Exercise panels use `win2k-window` with a navy `win2k-titlebar` header.
- **`BoxResult`** — Set rows use `win2k-raised`/`win2k-sunken` borders; form inputs use the classic sunken inset look.
- **`ButtonPlusIcon`** — Replaced rounded pill buttons with flat `win2k-btn` style with label text.
- **`[id].tsx`** — Form fields, labels, and the finish-time modal all restyled to Win2k window/dialog conventions.